### PR TITLE
feat: lazy load secondary sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Recycle, Building2, Guitar as Hospital, Home, ChevronDown, Phone, Mail, MapPin, Facebook, Twitter, Linkedin, ArrowRight, Truck, LeafyGreen, Factory, Trash2 } from 'lucide-react';
+import React, { Suspense } from 'react';
+import { Recycle, ChevronDown, ArrowRight } from 'lucide-react';
 
 const Navigation = () => (
   <nav className="fixed top-0 w-full bg-white/95 backdrop-blur-sm z-50 shadow-sm">
@@ -58,188 +58,29 @@ const Hero = () => (
   </div>
 );
 
-const Solutions = () => (
-  <div className="py-24 bg-gray-50">
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div className="text-center max-w-3xl mx-auto mb-16">
-        <h2 className="text-4xl font-bold mb-4 text-gray-900">Comprehensive Waste Solutions</h2>
-        <p className="text-lg text-gray-600">Tailored waste management services for every sector, ensuring environmental compliance and sustainability.</p>
-      </div>
-      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-        {[
-          { icon: Hospital, title: 'Medical Waste Management', desc: 'Safe disposal of clinical and biohazardous materials' },
-          { icon: Factory, title: 'Industrial Solutions', desc: 'Custom programs for manufacturing and processing facilities' },
-          { icon: Home, title: 'Municipal Services', desc: 'Efficient collection and processing for communities' },
-          { icon: LeafyGreen, title: 'Green Initiatives', desc: 'Sustainable recycling and composting programs' }
-        ].map((solution, index) => (
-          <div
-            key={index}
-            className="bg-white p-8 rounded-xl shadow-lg hover:shadow-xl transition group cursor-pointer border border-gray-100"
-          >
-            <div className="bg-primary-50 p-3 rounded-lg w-fit group-hover:bg-primary-100 transition">
-              <solution.icon className="h-8 w-8 text-primary-600 group-hover:scale-110 transition" />
-            </div>
-            <h3 className="text-xl font-semibold mt-6 mb-4">{solution.title}</h3>
-            <p className="text-gray-600">{solution.desc}</p>
-          </div>
-        ))}
-      </div>
-    </div>
-  </div>
-);
-
-const Stats = () => (
-  <div className="bg-secondary-900 py-20 relative overflow-hidden">
-    <div className="absolute inset-0 hero-pattern opacity-5" />
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative">
-      <div className="grid md:grid-cols-3 gap-12 text-center">
-        {[
-          { number: '500K+', label: 'Tons Processed Annually' },
-          { number: '1000+', label: 'Business Clients' },
-          { number: '99.9%', label: 'Environmental Compliance' }
-        ].map((stat, index) => (
-          <div key={index} className="bg-secondary-800/50 p-8 rounded-xl backdrop-blur-sm">
-            <div className="text-5xl font-bold text-white mb-2">{stat.number}</div>
-            <div className="text-primary-400 font-medium text-lg">{stat.label}</div>
-          </div>
-        ))}
-      </div>
-    </div>
-  </div>
-);
-
-const Contact = () => (
-  <div className="py-24 bg-white" id="contact">
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div className="grid md:grid-cols-2 gap-16">
-        <div>
-          <h2 className="text-4xl font-bold mb-4">Let's Talk Sustainability</h2>
-          <p className="text-lg text-gray-600 mb-8">Get in touch with our waste management experts to discuss your specific needs and requirements.</p>
-          <form className="space-y-6">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Name</label>
-              <input type="text" className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Email</label>
-              <input type="email" className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Message</label>
-              <textarea rows={4} className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"></textarea>
-            </div>
-            <button className="bg-primary-600 text-white px-8 py-3 rounded-full hover:bg-primary-700 transition font-semibold w-full md:w-auto">
-              Send Message
-            </button>
-          </form>
-        </div>
-        <div>
-          <div className="bg-gray-50 p-8 rounded-xl border border-gray-100">
-            <h3 className="text-2xl font-semibold mb-6">Contact Information</h3>
-            <div className="space-y-6">
-              <div className="flex items-center">
-                <div className="bg-primary-100 p-3 rounded-lg">
-                  <Phone className="h-6 w-6 text-primary-600" />
-                </div>
-                <div className="ml-4">
-                  <p className="text-sm text-gray-500">Call Us</p>
-                  <p className="font-medium">+1 (555) 123-4567</p>
-                </div>
-              </div>
-              <div className="flex items-center">
-                <div className="bg-primary-100 p-3 rounded-lg">
-                  <Mail className="h-6 w-6 text-primary-600" />
-                </div>
-                <div className="ml-4">
-                  <p className="text-sm text-gray-500">Email Us</p>
-                  <p className="font-medium">contact@saidaesp.com</p>
-                </div>
-              </div>
-              <div className="flex items-center">
-                <div className="bg-primary-100 p-3 rounded-lg">
-                  <MapPin className="h-6 w-6 text-primary-600" />
-                </div>
-                <div className="ml-4">
-                  <p className="text-sm text-gray-500">Visit Us</p>
-                  <p className="font-medium">123 Business Street, City, Country</p>
-                </div>
-              </div>
-            </div>
-            <div className="mt-8 pt-8 border-t border-gray-200">
-              <h4 className="text-lg font-semibold mb-4">Connect With Us</h4>
-              <div className="flex space-x-4">
-                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
-                  <Facebook className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
-                </a>
-                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
-                  <Twitter className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
-                </a>
-                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
-                  <Linkedin className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-const Footer = () => (
-  <footer className="bg-gray-900 text-white py-16">
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div className="grid md:grid-cols-4 gap-12">
-        <div>
-          <div className="flex items-center mb-6">
-            <Recycle className="h-8 w-8 text-primary-500" />
-            <span className="ml-2 text-xl font-bold">SAIDA S.A. E.S.P.</span>
-          </div>
-          <p className="text-gray-400">Pioneering sustainable waste management solutions for a cleaner, greener future.</p>
-        </div>
-        <div>
-          <h4 className="text-lg font-semibold mb-6">Quick Links</h4>
-          <ul className="space-y-4 text-gray-400">
-            <li><a href="#" className="hover:text-primary-500 transition">About Us</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Services</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Solutions</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Contact</a></li>
-          </ul>
-        </div>
-        <div>
-          <h4 className="text-lg font-semibold mb-6">Services</h4>
-          <ul className="space-y-4 text-gray-400">
-            <li><a href="#" className="hover:text-primary-500 transition">Medical Waste</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Industrial Waste</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Municipal Waste</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Recycling</a></li>
-          </ul>
-        </div>
-        <div>
-          <h4 className="text-lg font-semibold mb-6">Legal</h4>
-          <ul className="space-y-4 text-gray-400">
-            <li><a href="#" className="hover:text-primary-500 transition">Privacy Policy</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Terms of Service</a></li>
-            <li><a href="#" className="hover:text-primary-500 transition">Cookie Policy</a></li>
-          </ul>
-        </div>
-      </div>
-      <div className="border-t border-gray-800 mt-12 pt-8 text-center text-gray-400">
-        <p>&copy; 2024 SAIDA S.A. E.S.P. All rights reserved.</p>
-      </div>
-    </div>
-  </footer>
-);
+const Solutions = React.lazy(() => import('./components/Solutions'));
+const Stats = React.lazy(() => import('./components/Stats'));
+const Contact = React.lazy(() => import('./components/Contact'));
+const Footer = React.lazy(() => import('./components/Footer'));
+const Loader = <div className="text-center py-10">Loading...</div>;
 
 function App() {
   return (
     <div className="min-h-screen">
       <Navigation />
       <Hero />
-      <Solutions />
-      <Stats />
-      <Contact />
-      <Footer />
+      <Suspense fallback={Loader}>
+        <Solutions />
+      </Suspense>
+      <Suspense fallback={Loader}>
+        <Stats />
+      </Suspense>
+      <Suspense fallback={Loader}>
+        <Contact />
+      </Suspense>
+      <Suspense fallback={Loader}>
+        <Footer />
+      </Suspense>
     </div>
   );
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Phone, Mail, MapPin, Facebook, Twitter, Linkedin } from 'lucide-react';
+
+const Contact = () => (
+  <div className="py-24 bg-white" id="contact">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="grid md:grid-cols-2 gap-16">
+        <div>
+          <h2 className="text-4xl font-bold mb-4">Let's Talk Sustainability</h2>
+          <p className="text-lg text-gray-600 mb-8">Get in touch with our waste management experts to discuss your specific needs and requirements.</p>
+          <form className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Name</label>
+              <input type="text" className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Email</label>
+              <input type="email" className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Message</label>
+              <textarea rows={4} className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"></textarea>
+            </div>
+            <button className="bg-primary-600 text-white px-8 py-3 rounded-full hover:bg-primary-700 transition font-semibold w-full md:w-auto">
+              Send Message
+            </button>
+          </form>
+        </div>
+        <div>
+          <div className="bg-gray-50 p-8 rounded-xl border border-gray-100">
+            <h3 className="text-2xl font-semibold mb-6">Contact Information</h3>
+            <div className="space-y-6">
+              <div className="flex items-center">
+                <div className="bg-primary-100 p-3 rounded-lg">
+                  <Phone className="h-6 w-6 text-primary-600" />
+                </div>
+                <div className="ml-4">
+                  <p className="text-sm text-gray-500">Call Us</p>
+                  <p className="font-medium">+1 (555) 123-4567</p>
+                </div>
+              </div>
+              <div className="flex items-center">
+                <div className="bg-primary-100 p-3 rounded-lg">
+                  <Mail className="h-6 w-6 text-primary-600" />
+                </div>
+                <div className="ml-4">
+                  <p className="text-sm text-gray-500">Email Us</p>
+                  <p className="font-medium">contact@saidaesp.com</p>
+                </div>
+              </div>
+              <div className="flex items-center">
+                <div className="bg-primary-100 p-3 rounded-lg">
+                  <MapPin className="h-6 w-6 text-primary-600" />
+                </div>
+                <div className="ml-4">
+                  <p className="text-sm text-gray-500">Visit Us</p>
+                  <p className="font-medium">123 Business Street, City, Country</p>
+                </div>
+              </div>
+            </div>
+            <div className="mt-8 pt-8 border-t border-gray-200">
+              <h4 className="text-lg font-semibold mb-4">Connect With Us</h4>
+              <div className="flex space-x-4">
+                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
+                  <Facebook className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
+                </a>
+                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
+                  <Twitter className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
+                </a>
+                <a href="#" className="bg-gray-100 p-3 rounded-lg hover:bg-primary-100 transition group">
+                  <Linkedin className="h-5 w-5 text-gray-600 group-hover:text-primary-600" />
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default Contact;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Recycle } from 'lucide-react';
+
+const Footer = () => (
+  <footer className="bg-gray-900 text-white py-16">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="grid md:grid-cols-4 gap-12">
+        <div>
+          <div className="flex items-center mb-6">
+            <Recycle className="h-8 w-8 text-primary-500" />
+            <span className="ml-2 text-xl font-bold">SAIDA S.A. E.S.P.</span>
+          </div>
+          <p className="text-gray-400">Pioneering sustainable waste management solutions for a cleaner, greener future.</p>
+        </div>
+        <div>
+          <h4 className="text-lg font-semibold mb-6">Quick Links</h4>
+          <ul className="space-y-4 text-gray-400">
+            <li><a href="#" className="hover:text-primary-500 transition">About Us</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Services</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Solutions</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Contact</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-lg font-semibold mb-6">Services</h4>
+          <ul className="space-y-4 text-gray-400">
+            <li><a href="#" className="hover:text-primary-500 transition">Medical Waste</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Industrial Waste</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Municipal Waste</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Recycling</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-lg font-semibold mb-6">Legal</h4>
+          <ul className="space-y-4 text-gray-400">
+            <li><a href="#" className="hover:text-primary-500 transition">Privacy Policy</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Terms of Service</a></li>
+            <li><a href="#" className="hover:text-primary-500 transition">Cookie Policy</a></li>
+          </ul>
+        </div>
+      </div>
+      <div className="border-t border-gray-800 mt-12 pt-8 text-center text-gray-400">
+        <p>&copy; 2024 SAIDA S.A. E.S.P. All rights reserved.</p>
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/Solutions.tsx
+++ b/src/components/Solutions.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Stethoscope, Factory, Home, LeafyGreen } from 'lucide-react';
+
+const Solutions = () => (
+  <div className="py-24 bg-gray-50">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="text-center max-w-3xl mx-auto mb-16">
+        <h2 className="text-4xl font-bold mb-4 text-gray-900">Comprehensive Waste Solutions</h2>
+        <p className="text-lg text-gray-600">Tailored waste management services for every sector, ensuring environmental compliance and sustainability.</p>
+      </div>
+      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+        {[
+          { icon: Stethoscope, title: 'Medical Waste Management', desc: 'Safe disposal of clinical and biohazardous materials' },
+          { icon: Factory, title: 'Industrial Solutions', desc: 'Custom programs for manufacturing and processing facilities' },
+          { icon: Home, title: 'Municipal Services', desc: 'Efficient collection and processing for communities' },
+          { icon: LeafyGreen, title: 'Green Initiatives', desc: 'Sustainable recycling and composting programs' }
+        ].map((solution, index) => (
+          <div
+            key={index}
+            className="bg-white p-8 rounded-xl shadow-lg hover:shadow-xl transition group cursor-pointer border border-gray-100"
+          >
+            <div className="bg-primary-50 p-3 rounded-lg w-fit group-hover:bg-primary-100 transition">
+              <solution.icon className="h-8 w-8 text-primary-600 group-hover:scale-110 transition" />
+            </div>
+            <h3 className="text-xl font-semibold mt-6 mb-4">{solution.title}</h3>
+            <p className="text-gray-600">{solution.desc}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default Solutions;

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const Stats = () => (
+  <div className="bg-secondary-900 py-20 relative overflow-hidden">
+    <div className="absolute inset-0 hero-pattern opacity-5" />
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative">
+      <div className="grid md:grid-cols-3 gap-12 text-center">
+        {[
+          { number: '500K+', label: 'Tons Processed Annually' },
+          { number: '1000+', label: 'Business Clients' },
+          { number: '99.9%', label: 'Environmental Compliance' }
+        ].map((stat, index) => (
+          <div key={index} className="bg-secondary-800/50 p-8 rounded-xl backdrop-blur-sm">
+            <div className="text-5xl font-bold text-white mb-2">{stat.number}</div>
+            <div className="text-primary-400 font-medium text-lg">{stat.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
+export default Stats;


### PR DESCRIPTION
## Summary
- split Solutions, Stats, Contact, and Footer into separate components
- lazy load secondary sections with React.lazy and Suspense
- render lazily loaded sections independently and use a medical-specific icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7bddaeb4c832abc2cf2b453c034e5